### PR TITLE
Update mcmod.info

### DIFF
--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -1,19 +1,17 @@
-[
-{
+[{
   "modid": "badores",
   "name": "Bad Ores",
   "description": "Adding tons of Ores, potentially maybe not useful.",
-  "version": "",
+  "version": "${version}",
+  "mcversion": "${mcversion}",
   "credits": "",
   "logoFile": "",
-  "mcversion": "",
   "url":  "",
   "updateUrl": "",
   "authorList": [ "Ivorius", "TripleHeadedSheep", "diesieben07" ],
   "parent": "",
   "screenshots": [],
   "dependencies": [
-         "Forge"
-    ]
-}
-]
+   "Forge"
+  ]
+}]


### PR DESCRIPTION
The mcmod.info file doesn't contain any version information. [mod version or mc version]

Most mods use the `${version}` and `${mcversion}` variables in their source mcmod.info file.
To my [limited] knowledge I believe that gradle automatically those variables with the correct information in the newly built jar file.
- `${version}` variable should be replaced with the Mod Version (eg 2.0.0.0), 
- `${mcversion}` variable should be replaced with the Minecraft Version (eg 1.7.10)

I came across this issue since I have scripts that automatically process mods by using their modid, version, and mcversion.
